### PR TITLE
Allow immutable objects to be used as the configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "http://github.com/andris9/nodemailer-smtp-transport",
   "dependencies": {
+    "mout": "^0.11.0",
     "nodemailer-wellknown": "^0.1.5",
     "smtp-connection": "^1.2.0"
   },

--- a/src/smtp-transport.js
+++ b/src/smtp-transport.js
@@ -2,6 +2,7 @@
 
 var SMTPConnection = require('smtp-connection');
 var packageData = require('../package.json');
+var mout = require('mout');
 var wellknown = require('nodemailer-wellknown');
 
 var EventEmitter = require('events').EventEmitter;
@@ -9,7 +10,7 @@ var util = require('util');
 
 // expose to the world
 module.exports = function(options) {
-    return new SMTPTransport(options);
+    return new SMTPTransport(mout.lang.deepClone(options));
 };
 
 /**

--- a/test/smtp-tranport-test.js
+++ b/test/smtp-tranport-test.js
@@ -253,4 +253,25 @@ describe('SMTP Transport Tests', function() {
             });
         });
     });
+
+    describe('General tests', function(){
+
+        it('Should accept immutable config object', function(){
+            var config = {
+                host: 'example.com',
+                port: 465,
+                auth: {
+                    user: 'example@example.com',
+                    pass: 'example'
+                }
+            };
+
+            Object.freeze(config);
+
+            expect(function(){
+                new smtpTransport(config);
+            }).to.not.throw(Error);
+        });
+
+    });
 });


### PR DESCRIPTION
Altering directly the config object isn't a good practice and can lead to errors as we can see [here][0]. This pull request uses mout to make a deep clone from the original config object.

[0]: https://github.com/andris9/Nodemailer/issues/428