### PR TITLE
Unify transport typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Where
 **Example**
 
 ```javascript
-var transport = nodemailer.createTransport(smtpTransport({
+var transporter = nodemailer.createTransport(smtpTransport({
     host: 'localhost',
     port: 25,
     auth: {


### PR DESCRIPTION
Change `transport` variable to `transporter` in README.md
to unify with the other example codes

*it can cause a half bit of confusion when copy-pasting code :)*